### PR TITLE
Fix Z hop in clicky unload macro

### DIFF
--- a/macros/zprobe/unloadclicky.g
+++ b/macros/zprobe/unloadclicky.g
@@ -21,7 +21,7 @@ if global.clicky_status != "docked"
 	G1 X30 ; wipe off
 	G90 ; absolute
 	M98 P"/macros/moveto/clickstage.g"
-	M98 P"/macros/moveto/hominghopdown.g"	; raise Z if homed already
+	M98 P"/macros/moveto/hominghopup.g"	; raise Z if homed already
 	M400
 	; check for probe trigger here
 	M98 P"/macros/zprobe/clicky_status.g"


### PR DESCRIPTION
There is a comment indicating that an upwards Z hop was intended in unloadclicky.g. It was instead calling the Z hop *down* macro, which caused the printhead to ram into the bed after QGL in my experience. This hop doesn't seem to be necessary at all, but we might as well correct it anyways.